### PR TITLE
use colorjizz ^1.0 release addresses davidgorges/color-contrast-php#1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ Using composer:
 composer require davidgorges/color-contrast
 ```
 
-**Note** that this package depends on development branches of other projects, so your [minimum stability][1]
-must be `dev` in `composer.json` otherwise you'll get a dependency resolution conflict.
-
-```json
-"minimum-stability": "dev",
-"prefer-stable" : true
-```
-
 ## Usage
 ````php
     use ColorContrast\ColorContrast;

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.3",
-        "mischiefcollective/colorjizz": "dev-master"
+        "mischiefcollective/colorjizz": "^1.0"
     },
     "require-dev": {
         "instaclick/php-code-sniffer": "dev-master",
@@ -17,5 +17,11 @@
         "psr-4": {
             "ColorContrast\\": "src/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mikeemoo/ColorJizz-PHP"
+        }
+    ]
 }


### PR DESCRIPTION
addresses #1 
per mikeemoo/ColorJizz-PHP#10

despite having added the 1.0.0 release, packagist still has not
crawled the repository to reflect the available stable version.

manually adding the Github repo as a vcs repository to composer.json
should actually speed things up for resolution on installation and
guarantee new release tags are picked up.

the only drawback would be if @mikeemoo deleted the repository from
Github all together. Github forwards transfers, so that shouldn't
break it either.